### PR TITLE
Fix: Exclude hero rarity from deck validation statistics

### DIFF
--- a/src/lib/deckValidation.ts
+++ b/src/lib/deckValidation.ts
@@ -170,9 +170,9 @@ export class DeckValidator {
 				if (hero.faction) {
 					stats.factionBreakdown[hero.faction] = (stats.factionBreakdown[hero.faction] || 0) + 1;
 				}
-				if (hero.rarity) {
-					stats.rarityBreakdown[hero.rarity] = (stats.rarityBreakdown[hero.rarity] || 0) + 1;
-				}
+				// if (hero.rarity) {
+				// 	stats.rarityBreakdown[hero.rarity] = (stats.rarityBreakdown[hero.rarity] || 0) + 1;
+				// }
 			}
 		}
 

--- a/tests/unit/DeckMachineRealCards.test.ts
+++ b/tests/unit/DeckMachineRealCards.test.ts
@@ -521,8 +521,8 @@ describe('Deck State Machine - Real Cards Tests', () => {
       const snapshot = actor.getSnapshot();
       const stats = snapshot.context.validationResult?.stats;
       
-      expect(stats?.rarityBreakdown['Commun']).toBe(2); // 1 common card + 1 common hero
-      expect(stats?.rarityBreakdown['Rare']).toBe(1);
+      expect(stats?.rarityBreakdown['Commun']).toBe(1); // Only AX_CHAR_COMMON (Common)
+      expect(stats?.rarityBreakdown['Rare']).toBe(1);   // AX_CHAR_RARE (Rare)
     });
   });
 });


### PR DESCRIPTION
Rule 2.2.5.c of the Altered Complete Rules states that "Heroes ... have no rarity." This commit updates the deck validation logic to align with this rule.

Previously, the `calculateStats` method in `deckValidation.ts` would include the hero's listed rarity (from the card data JSON) in the `rarityBreakdown` statistics. This change ensures that the hero's rarity is no longer counted.

Additionally, the relevant test case `it('should correctly track rarity breakdown with real cards', ...)` in `DeckMachineRealCards.test.ts` has been updated. The expected count for common cards in this test was adjusted to reflect that the hero's common rarity is no longer part of the calculation.

This change ensures more accurate deck validation against the official game rules.