### PR TITLE
feat: Enhance game engine progression and actions

### DIFF
--- a/src/engine/types/abilities.ts
+++ b/src/engine/types/abilities.ts
@@ -10,6 +10,7 @@ export interface ICost {
 	mana?: number;
 	discard?: { count: number; criteria?: unknown }; // criteria can be further defined
 	exhaustSelf?: boolean;
+	discardSelfFromReserve?: boolean; // Added for quick actions that discard the source card from reserve
 	sacrifice?: { count: number; criteria?: unknown };
 	spendCounters?: { type: CounterType; amount: number };
 }


### PR DESCRIPTION
I've implemented several key features and refinements to the game engine based on the rulebook:

1.  **Morning Phase - Expand Action (Rule 4.2.1.e):**
    - Added `expandMana` action to `PlayerActionHandler`.
    - `PhaseManager.handleMorning` now allows players to choose a card from hand (simulated choice) to move to their Mana zone as a ready, face-down Mana Orb.
    - Reactions are resolved after each expand action.

2.  **Night Phase - Clean-up Choice (Rule 4.2.5.c):**
    - `GameStateManager.cleanupPhase` now processes players in initiative order.
    - I've implemented simulated player choice (using heuristics based on card cost and age) for selecting which cards to keep in Reserve and Landmark zones if over the limit.
    - Non-selected cards are discarded (from Reserve) or sacrificed (from Landmark).

3.  **Quick Action Enhancements (Rules 1.2.4.c, 5.1.2, 7.3.10, 7.1.4):**
    - `IAbility` costs updated to support mana, exhaustSelf, and discardSelfFromReserve.
    - `PlayerActionHandler.getAvailableQuickActions` now checks these costs and object statuses.
    - `PlayerActionHandler.executeQuickAction` now pays the defined costs (mana, exhausting source object, discarding source object from reserve) before calling the `EffectProcessor` to resolve the ability's effect.
    - Daily activation limits for quick actions are enforced.

4.  **Counter Handling Validation (Rules 2.5.j, 2.5.k, 7.4.6.b):**
    - I've reviewed and refined the counter handling logic in `GameStateManager.moveEntity`.
    - This ensures counters are lost by default when moving from Expedition/Landmark zones (Rule 2.5.j).
    - Seasoned characters correctly retain only Boost counters when moving from Expedition to Reserve (Rule 7.4.6.b).
    - Objects moving from Reserve/Limbo to other visible zones (not discard/hidden) retain their counters (Rule 2.5.k).
    - Moving to discard or hidden zones results in loss of all counters.