### PR TITLE
Hi there! I've just refactored the Expedition Zone to be shared and i…

### DIFF
--- a/src/engine/ReactionManager.ts
+++ b/src/engine/ReactionManager.ts
@@ -151,14 +151,15 @@ export class ReactionManager {
 
 	private getAllGameObjects(): IGameObject[] {
 		const objects: IGameObject[] = [];
+		// Player-specific zones
 		this.gsm.state.players.forEach((player) => {
-			// In-Play zones
-			objects.push(...player.zones.expeditionZone.getAll().filter(isGameObject));
 			objects.push(...player.zones.landmarkZone.getAll().filter(isGameObject));
 			objects.push(...player.zones.heroZone.getAll().filter(isGameObject));
-			// Reserve zone (for support abilities)
-			objects.push(...player.zones.reserveZone.getAll().filter(isGameObject));
+			objects.push(...player.zones.reserveZone.getAll().filter(isGameObject)); // For support abilities
 		});
+		// Shared zones
+		objects.push(...this.gsm.state.sharedZones.expedition.getAll().filter(isGameObject));
+		// Adventure and Limbo zones are generally not sources of reaction abilities from objects within them.
 		return objects;
 	}
 }

--- a/src/engine/StatusEffectHandler.ts
+++ b/src/engine/StatusEffectHandler.ts
@@ -186,19 +186,20 @@ export class StatusEffectHandler {
 	 * Night phase status processing (during Rest)
 	 */
 	private processStatusEffectsDuringNight(): void {
+		const expeditionZone = this.gsm.state.sharedZones.expedition;
 		for (const player of this.gsm.state.players.values()) {
-			const expeditionZone = player.zones.expeditionZone;
+			const playerEntitiesInExpedition = expeditionZone.getAll().filter(
+				(e): e is IGameObject => isGameObject(e) && e.controllerId === player.id && e.type === CardType.Character
+			);
 
-			for (const entity of expeditionZone.getAll()) {
-				if (isGameObject(entity) && entity.type === CardType.Character) {
-					// Process Anchored and Asleep statuses
-					const wasAnchored = this.processAnchoredDuringRest(entity);
-					const wasAsleep = this.processAsleepDuringRest(entity);
+			for (const entity of playerEntitiesInExpedition) {
+				// Process Anchored and Asleep statuses
+				const wasAnchored = this.processAnchoredDuringRest(entity);
+				const wasAsleep = this.processAsleepDuringRest(entity);
 
-					// These statuses prevent going to Reserve
-					if (wasAnchored || wasAsleep) {
-						continue;
-					}
+				// These statuses prevent going to Reserve
+				if (wasAnchored || wasAsleep) {
+					continue;
 				}
 			}
 		}
@@ -271,9 +272,9 @@ export class StatusEffectHandler {
 			yield player.zones.reserveZone;
 			yield player.zones.landmarkZone;
 			yield player.zones.heroZone;
-			yield player.zones.expeditionZone;
 		}
 		yield this.gsm.state.sharedZones.adventure;
+		yield this.gsm.state.sharedZones.expedition; // Added shared expedition zone
 		yield this.gsm.state.sharedZones.limbo;
 	}
 }

--- a/src/engine/TiebreakerSystem.ts
+++ b/src/engine/TiebreakerSystem.ts
@@ -356,17 +356,23 @@ export class TiebreakerSystem {
 
 			// Process character status effects but don't move to Reserve
 			// since Arena combat continues
-			const expeditionChars = player.zones.expeditionZone
-				.getAll()
-				.filter((e) => isGameObject(e) && e.type === CardType.Character) as IGameObject[];
+			const sharedExpeditionZone = this.gsm.state.sharedZones.expedition;
+			const playerExpeditionChars = sharedExpeditionZone.getAll().filter(
+				(e): e is IGameObject =>
+					isGameObject(e) &&
+					e.controllerId === playerId &&
+					e.type === CardType.Character
+			);
 
-			for (const char of expeditionChars) {
+			for (const char of playerExpeditionChars) {
 				// Remove temporary statuses
 				if (char.statuses.has(StatusType.Anchored)) {
 					char.statuses.delete(StatusType.Anchored);
+					console.log(`[TiebreakerSystem] Removed Anchored from ${char.name} during Tiebreaker Rest.`);
 				}
 				if (char.statuses.has(StatusType.Asleep)) {
 					char.statuses.delete(StatusType.Asleep);
+					console.log(`[TiebreakerSystem] Removed Asleep from ${char.name} during Tiebreaker Rest.`);
 				}
 			}
 		}


### PR DESCRIPTION
…mplemented the Mana Zone rules.

This addresses discrepancies I found in the rulebook audit for Zones (Section 1.2.3 and Section 3).

Here's a summary of the key changes:
- Expedition Zone (Rule 1.2.3.d, 3.1.2.a, 3.2.4.a):
  - I refactored the Expedition Zone from per-player to a single shared zone (`state.sharedZones.expeditionZone`) in `GameStateManager.ts`.
  - I updated all engine references (`EffectProcessor.ts`, `StatusEffectHandler.ts`, `KeywordAbilityHandler.ts`, etc.) to use the shared zone, ensuring controller-specific logic by filtering by `object.controllerId`.
  - I aligned behavior with Rule 3.2.4.d (an object moving between conceptual expeditions within the shared zone is not a zone change).
- Mana Zone (Rule 3.2.9):
  - I ensured cards moved to the Mana Zone via `ManaSystem.expandMana` become face-down, exhausted `CardType.ManaOrb` objects (Rule 3.2.9.b).
  - I ensured initial mana orbs (Rule 4.1.k) are correctly set up as ready.
  - I implemented Rule 3.2.9.e by enhancing `ManaSystem.convertMana` to allow you to exhaust one mana orb to ready another, including validation and event publication.
- Documentation:
  - I updated `docs/rulebook_audit.md` to reflect these changes, marking the relevant rules as "Fully Implemented".

I also updated existing unit tests for `GameStateManager`, `EffectProcessor`, `CardPlaySystem`, `KeywordAbilityHandler`, and `StatusRules` to align with the shared Expedition Zone, and added new unit tests for `ManaSystem` to cover Mana Zone rule implementations (properties of cards entering mana, and converting mana orbs).