### PR TITLE
Implement Initiative Order for player choices and effects

### DIFF
--- a/src/engine/tests/unit/EffectProcessor.test.ts
+++ b/src/engine/tests/unit/EffectProcessor.test.ts
@@ -1,0 +1,220 @@
+import { EffectProcessor } from '../../EffectProcessor';
+import type { GameStateManager } from '../../GameStateManager';
+import { Player } from '../../Player';
+import type { PlayerActionHandler } from '../../PlayerActionHandler';
+import { ObjectStore } from '../../ObjectStore';
+import { EventBus } from '../../EventBus';
+import { RuleAdjudicator } from '../../RuleAdjudicator';
+import { TurnManager } from '../../TurnManager';
+import { Zone } from '../../Zone';
+import type { CardDefinition, IEffect, ICardInstance, IGameObject } from '../../types/objects';
+import { CardType, GamePhase, ZoneIdentifier, StatusType } from '../../types/enums';
+import { CardPlaySystem } from '../../CardPlaySystem';
+import { StatusHandler } from '../../StatusHandler';
+
+
+jest.mock('../../PlayerActionHandler');
+jest.mock('../../RuleAdjudicator');
+jest.mock('../../TurnManager');
+jest.mock('../../CardPlaySystem');
+jest.mock('../../StatusHandler');
+
+
+const mockPlayerActionHandler = {
+    playerChoosesObjectsToKeep: jest.fn(),
+    promptForOptionalStepChoice: jest.fn(),
+    promptForModeChoice: jest.fn(),
+    promptForCardChoice: jest.fn(),
+    promptForExpeditionChoice: jest.fn(),
+    promptForPlayerChoice: jest.fn(),
+    chooseTargetForEffect: jest.fn(),
+    promptPlayerForExpandChoice: jest.fn(),
+    promptPlayerForScoutChoice: jest.fn(),
+} as jest.Mocked<PlayerActionHandler>;
+
+describe('EffectProcessor', () => {
+    let effectProcessor: EffectProcessor;
+    let gsm: GameStateManager;
+    let player1: Player;
+    let player2: Player;
+    let objectStore: ObjectStore;
+    let eventBus: EventBus;
+    let ruleAdjudicator: RuleAdjudicator;
+    let turnManager: TurnManager;
+    let mockResolveReactions: jest.SpyInstance;
+    let mockApplyAllPassiveAbilities: jest.SpyInstance;
+    let cardPlaySystem: CardPlaySystem;
+    let statusHandler: StatusHandler;
+
+
+    const cardDefChar1: CardDefinition = { id: 'char1Def', name: 'Char1', type: CardType.Character };
+    const cardDefChar2: CardDefinition = { id: 'char2Def', name: 'Char2', type: CardType.Character };
+    const cardDefDeck1_P1: CardDefinition = { id: 'deck1_p1', name: 'P1Deck1', type: CardType.Character };
+    const cardDefDeck2_P1: CardDefinition = { id: 'deck2_p1', name: 'P1Deck2', type: CardType.Character };
+    const cardDefDeck1_P2: CardDefinition = { id: 'deck1_p2', name: 'P2Deck1', type: CardType.Character };
+    const cardDefDeck2_P2: CardDefinition = { id: 'deck2_p2', name: 'P2Deck2', type: CardType.Character };
+
+
+    beforeEach(() => {
+        eventBus = new EventBus(); // Real EventBus
+        objectStore = new ObjectStore(eventBus);
+        statusHandler = new StatusHandler(objectStore, eventBus);
+        ruleAdjudicator = new RuleAdjudicator(objectStore, eventBus, statusHandler);
+        turnManager = new TurnManager(eventBus, ['p1', 'p2']);
+
+        player1 = new Player('p1', 'Player 1', objectStore, eventBus);
+        player2 = new Player('p2', 'Player 2', objectStore, eventBus);
+
+        objectStore.addPlayer(player1);
+        objectStore.addPlayer(player2);
+
+        objectStore.registerCardDefinition(cardDefChar1);
+        objectStore.registerCardDefinition(cardDefChar2);
+        objectStore.registerCardDefinition(cardDefDeck1_P1);
+        objectStore.registerCardDefinition(cardDefDeck2_P1);
+        objectStore.registerCardDefinition(cardDefDeck1_P2);
+        objectStore.registerCardDefinition(cardDefDeck2_P2);
+
+        gsm = new GameStateManager(
+            objectStore,
+            eventBus,
+            ruleAdjudicator,
+            mockPlayerActionHandler as PlayerActionHandler,
+            turnManager,
+            statusHandler
+        );
+        cardPlaySystem = new CardPlaySystem(gsm);
+        effectProcessor = new EffectProcessor(gsm);
+        gsm.effectProcessor = effectProcessor;
+        gsm.cardPlaySystem = cardPlaySystem;
+
+        gsm.initializeGame(['p1', 'p2'], {});
+        gsm.startGame();
+        gsm.state.firstPlayerId = 'p1';
+        gsm.state.currentPlayerId = 'p1';
+        gsm.state.currentPhase = GamePhase.Morning; // Non-Afternoon phase
+
+        mockResolveReactions = jest.spyOn(gsm, 'resolveReactions').mockResolvedValue(undefined);
+        mockApplyAllPassiveAbilities = jest.spyOn(ruleAdjudicator, 'applyAllPassiveAbilities').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('\'Each player...\' effects', () => {
+        it('processes "Each player draws 1 card" in initiative order with reactions', async () => {
+            const p1_deck_card1 = objectStore.createCardInstance('deck1_p1', 'p1', ZoneIdentifier.Deck) as ICardInstance;
+            const p1_deck_card2 = objectStore.createCardInstance('deck2_p1', 'p1', ZoneIdentifier.Deck) as ICardInstance;
+            player1.zones.deckZone.addOrder([p1_deck_card1.instanceId, p1_deck_card2.instanceId].map(id => objectStore.getObject(id) as IGameObject));
+
+            const p2_deck_card1 = objectStore.createCardInstance('deck1_p2', 'p2', ZoneIdentifier.Deck) as ICardInstance;
+            const p2_deck_card2 = objectStore.createCardInstance('deck2_p2', 'p2', ZoneIdentifier.Deck) as ICardInstance;
+            player2.zones.deckZone.addOrder([p2_deck_card1.instanceId, p2_deck_card2.instanceId].map(id => objectStore.getObject(id) as IGameObject));
+
+            const drawEffect: IEffect = {
+                sourceObjectId: 'testSource',
+                steps: [{ verb: 'draw_cards', targets: 'all_players', parameters: { count: 1 } }]
+            };
+
+            const p1DrawOrder = { passives: 0, reaction: 0, handSize: 0 };
+            const p2DrawOrder = { passives: 0, reaction: 0, handSize: 0 };
+            let callSequence = 0;
+
+            mockApplyAllPassiveAbilities.mockImplementation(() => {
+                callSequence++;
+                if (player1.zones.handZone.getAll().length === 1 && p1DrawOrder.passives === 0) p1DrawOrder.passives = callSequence;
+                if (player2.zones.handZone.getAll().length === 1 && p2DrawOrder.passives === 0) p2DrawOrder.passives = callSequence;
+            });
+            mockResolveReactions.mockImplementation(async () => {
+                callSequence++;
+                if (player1.zones.handZone.getAll().length === 1 && p1DrawOrder.reaction === 0) p1DrawOrder.reaction = callSequence;
+                if (player2.zones.handZone.getAll().length === 1 && p2DrawOrder.reaction === 0) p2DrawOrder.reaction = callSequence;
+                return Promise.resolve();
+            });
+
+            jest.spyOn(gsm, 'drawCards').mockImplementation(async (playerId, count) => {
+                const player = gsm.getPlayer(playerId);
+                const card = player?.zones.deckZone.draw();
+                if (card && player) {
+                    player.zones.handZone.add(card);
+                    eventBus.publish('cardDrawn', { playerId, cardId: card.objectId, definitionId: card.definitionId });
+                    if (playerId === 'p1') p1DrawOrder.handSize = player.zones.handZone.getAll().length;
+                    if (playerId === 'p2') p2DrawOrder.handSize = player.zones.handZone.getAll().length;
+                }
+                return !!card;
+            });
+
+            await effectProcessor.resolveEffect(drawEffect);
+
+            expect(player1.zones.handZone.getAll().length).toBe(1);
+            expect(player1.zones.handZone.contains(p1_deck_card1.instanceId)).toBe(true);
+            expect(p1DrawOrder.passives).toBeLessThan(p1DrawOrder.reaction);
+
+            expect(player2.zones.handZone.getAll().length).toBe(1);
+            expect(player2.zones.handZone.contains(p2_deck_card1.instanceId)).toBe(true);
+            expect(p2DrawOrder.passives).toBeLessThan(p2DrawOrder.reaction);
+
+            expect(p1DrawOrder.reaction).toBeLessThan(p2DrawOrder.passives);
+        });
+
+        it('processes "Each player sacrifices 1 character" in initiative order with reactions and choices', async () => {
+            const char1_P1 = objectStore.createCardInstance('char1Def', 'p1', ZoneIdentifier.Play) as ICardInstance;
+            player1.zones.playZone.add(objectStore.getObject(char1_P1.instanceId) as IGameObject);
+            const char2_P2 = objectStore.createCardInstance('char2Def', 'p2', ZoneIdentifier.Play) as ICardInstance;
+            player2.zones.playZone.add(objectStore.getObject(char2_P2.instanceId) as IGameObject);
+
+            const sacrificeEffect: IEffect = {
+                sourceObjectId: 'testSource',
+                steps: [{
+                    verb: 'sacrifice',
+                    targets: 'all_players',
+                    parameters: {
+                        choiceCriteria: { type: CardType.Character }
+                    }
+                }]
+            };
+
+            const p1Order = { choice: 0, passives: 0, reaction: 0, cardInDiscard: false };
+            const p2Order = { choice: 0, passives: 0, reaction: 0, cardInDiscard: false };
+            let actionCallOrder = 0;
+
+            mockPlayerActionHandler.promptForCardChoice.mockImplementation(async (playerId, prompt, cards, min, max) => {
+                actionCallOrder++;
+                if (playerId === 'p1') {
+                    p1Order.choice = actionCallOrder;
+                    return cards.filter(c => c.definitionId === 'char1Def');
+                }
+                if (playerId === 'p2') {
+                    p2Order.choice = actionCallOrder;
+                    return cards.filter(c => c.definitionId === 'char2Def');
+                }
+                return [];
+            });
+
+            mockApplyAllPassiveAbilities.mockImplementation(() => {
+                actionCallOrder++;
+                if (p1Order.choice > 0 && p1Order.passives === 0 && player1.zones.discardPileZone.contains(char1_P1.instanceId)) p1Order.passives = actionCallOrder;
+                if (p2Order.choice > 0 && p2Order.passives === 0 && player2.zones.discardPileZone.contains(char2_P2.instanceId)) p2Order.passives = actionCallOrder;
+            });
+            mockResolveReactions.mockImplementation(async () => {
+                actionCallOrder++;
+                 if (p1Order.choice > 0 && p1Order.reaction === 0 && player1.zones.discardPileZone.contains(char1_P1.instanceId)) p1Order.reaction = actionCallOrder;
+                 if (p2Order.choice > 0 && p2Order.reaction === 0 && player2.zones.discardPileZone.contains(char2_P2.instanceId)) p2Order.reaction = actionCallOrder;
+                return Promise.resolve();
+            });
+
+            await effectProcessor.resolveEffect(sacrificeEffect);
+
+            expect(p1Order.choice).toBe(1);
+            expect(player1.zones.discardPileZone.contains(char1_P1.instanceId)).toBe(true);
+            expect(p1Order.passives).toBeGreaterThan(p1Order.choice);
+            expect(p1Order.reaction).toBeGreaterThan(p1Order.passives);
+
+            expect(p2Order.choice).toBeGreaterThan(p1Order.reaction);
+            expect(player2.zones.discardPileZone.contains(char2_P2.instanceId)).toBe(true);
+            expect(p2Order.passives).toBeGreaterThan(p2Order.choice);
+            expect(p2Order.reaction).toBeGreaterThan(p2Order.passives);
+        });
+    });
+});

--- a/src/engine/tests/unit/GameStateManager.test.ts
+++ b/src/engine/tests/unit/GameStateManager.test.ts
@@ -1,0 +1,164 @@
+import { GameStateManager } from '../../GameStateManager';
+import { Player } from '../../Player';
+import type { PlayerActionHandler } from '../../PlayerActionHandler';
+import type { CardDefinition, ICardInstance, IGameObject } from '../../types/objects';
+import { CardType, GamePhase, ZoneIdentifier } from '../../types/enums';
+import { ObjectStore } from '../../ObjectStore';
+import { EventBus } from '../../EventBus';
+import { RuleAdjudicator } from '../../RuleAdjudicator';
+import { TurnManager } from '../../TurnManager';
+import { Zone } from '../../Zone';
+import { EffectProcessor } from '../../EffectProcessor';
+import { CardPlaySystem } from '../../CardPlaySystem';
+import { StatusHandler } from '../../StatusHandler';
+
+
+jest.mock('../../PlayerActionHandler');
+jest.mock('../../EventBus');
+jest.mock('../../RuleAdjudicator');
+jest.mock('../../TurnManager');
+jest.mock('../../EffectProcessor');
+jest.mock('../../CardPlaySystem');
+jest.mock('../../StatusHandler');
+
+
+const mockPlayerActionHandler = {
+    playerChoosesObjectsToKeep: jest.fn(),
+    promptForOptionalStepChoice: jest.fn(),
+    promptForModeChoice: jest.fn(),
+    promptForCardChoice: jest.fn(),
+    promptForExpeditionChoice: jest.fn(),
+    promptForPlayerChoice: jest.fn(),
+    chooseTargetForEffect: jest.fn(),
+    promptPlayerForExpandChoice: jest.fn(),
+    promptPlayerForScoutChoice: jest.fn(),
+} as jest.Mocked<PlayerActionHandler>;
+
+
+describe('GameStateManager', () => {
+    let gsm: GameStateManager;
+    let player1: Player;
+    let player2: Player;
+    let objectStore: ObjectStore;
+    let eventBus: EventBus;
+    let ruleAdjudicator: RuleAdjudicator;
+    let turnManager: TurnManager;
+    let effectProcessor: EffectProcessor;
+    let cardPlaySystem: CardPlaySystem;
+    let statusHandler: StatusHandler;
+
+    const cardDefReserveLimit: CardDefinition = { id: 'heroDef', name: 'Hero', type: CardType.Hero, characteristics: { reserve: 1 } };
+    const cardDefA: CardDefinition = { id: 'cardADef', name: 'Card A', type: CardType.Character, cost: { scout: 1 } };
+    const cardDefB: CardDefinition = { id: 'cardBDef', name: 'Card B', type: CardType.Character, cost: { scout: 1 } };
+    const cardDefC: CardDefinition = { id: 'cardCDef', name: 'Card C', type: CardType.Character, cost: { scout: 1 } };
+    const cardDefX: CardDefinition = { id: 'cardXDef', name: 'Card X', type: CardType.Character, cost: { scout: 1 } };
+    const cardDefY: CardDefinition = { id: 'cardYDef', name: 'Card Y', type: CardType.Character, cost: { scout: 1 } };
+    const cardDefZ: CardDefinition = { id: 'cardZDef', name: 'Card Z', type: CardType.Character, cost: { scout: 1 } };
+
+    beforeEach(() => {
+        eventBus = new EventBus();
+        objectStore = new ObjectStore(eventBus);
+        statusHandler = new StatusHandler(objectStore, eventBus);
+        ruleAdjudicator = new RuleAdjudicator(objectStore, eventBus, statusHandler);
+        turnManager = new TurnManager(eventBus, ['p1', 'p2']);
+        effectProcessor = new EffectProcessor({} as GameStateManager); // Will be replaced by actual gsm
+        cardPlaySystem = new CardPlaySystem({} as GameStateManager); // Will be replaced by actual gsm
+
+
+        player1 = new Player('p1', 'Player 1', objectStore, eventBus);
+        player2 = new Player('p2', 'Player 2', objectStore, eventBus);
+
+        objectStore.addPlayer(player1);
+        objectStore.addPlayer(player2);
+
+        objectStore.registerCardDefinition(cardDefReserveLimit);
+        objectStore.registerCardDefinition(cardDefA);
+        objectStore.registerCardDefinition(cardDefB);
+        objectStore.registerCardDefinition(cardDefC);
+        objectStore.registerCardDefinition(cardDefX);
+        objectStore.registerCardDefinition(cardDefY);
+        objectStore.registerCardDefinition(cardDefZ);
+
+        gsm = new GameStateManager(
+            objectStore,
+            eventBus,
+            ruleAdjudicator,
+            mockPlayerActionHandler as PlayerActionHandler,
+            turnManager,
+            statusHandler
+        );
+        effectProcessor['gsm'] = gsm;
+        cardPlaySystem['gsm'] = gsm;
+        gsm.effectProcessor = effectProcessor;
+        gsm.cardPlaySystem = cardPlaySystem;
+
+
+        gsm.initializeGame(['p1', 'p2'], { p1: ['heroDef'], p2: ['heroDef'] });
+        gsm.startGame();
+        gsm.state.firstPlayerId = 'p1';
+        gsm.state.currentPlayerId = 'p1';
+        gsm.state.currentPhase = GamePhase.Cleanup;
+
+
+        const hero1 = player1.zones.heroZone.getObjectsByDefinitionId('heroDef')[0] as IGameObject;
+        const hero2 = player2.zones.heroZone.getObjectsByDefinitionId('heroDef')[0] as IGameObject;
+
+        if(hero1) objectStore.updateObjectCharacteristics(hero1.objectId, { reserve: 1 });
+        if(hero2) objectStore.updateObjectCharacteristics(hero2.objectId, { reserve: 1 });
+
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('cleanupPhase', () => {
+        it('should process reserve limit cleanup in initiative order and move excess cards to discard', async () => {
+            const cardA_P1 = objectStore.createCardInstance('cardADef', 'p1', ZoneIdentifier.Reserve) as ICardInstance;
+            const cardB_P1 = objectStore.createCardInstance('cardBDef', 'p1', ZoneIdentifier.Reserve) as ICardInstance;
+            const cardC_P1 = objectStore.createCardInstance('cardCDef', 'p1', ZoneIdentifier.Reserve) as ICardInstance;
+            player1.zones.reserveZone.add(objectStore.getObject(cardA_P1.instanceId) as IGameObject);
+            player1.zones.reserveZone.add(objectStore.getObject(cardB_P1.instanceId) as IGameObject);
+            player1.zones.reserveZone.add(objectStore.getObject(cardC_P1.instanceId) as IGameObject);
+
+            const cardX_P2 = objectStore.createCardInstance('cardXDef', 'p2', ZoneIdentifier.Reserve) as ICardInstance;
+            const cardY_P2 = objectStore.createCardInstance('cardYDef', 'p2', ZoneIdentifier.Reserve) as ICardInstance;
+            const cardZ_P2 = objectStore.createCardInstance('cardZDef', 'p2', ZoneIdentifier.Reserve) as ICardInstance;
+            player2.zones.reserveZone.add(objectStore.getObject(cardX_P2.instanceId) as IGameObject);
+            player2.zones.reserveZone.add(objectStore.getObject(cardY_P2.instanceId) as IGameObject);
+            player2.zones.reserveZone.add(objectStore.getObject(cardZ_P2.instanceId) as IGameObject);
+
+            const p1KeepOrder: Record<string, number> = {};
+            const p2KeepOrder: Record<string, number> = {};
+            let callCount = 0;
+
+            mockPlayerActionHandler.playerChoosesObjectsToKeep.mockImplementation(async (playerId, objects, limit, reason) => {
+                callCount++;
+                if (playerId === 'p1') {
+                    p1KeepOrder[playerId] = callCount;
+                    return objects.filter(obj => obj.definitionId === 'cardADef');
+                }
+                if (playerId === 'p2') {
+                    p2KeepOrder[playerId] = callCount;
+                    return objects.filter(obj => obj.definitionId === 'cardXDef');
+                }
+                return [];
+            });
+
+            await gsm.cleanupPhase();
+
+            expect(p1KeepOrder['p1']).toBe(1);
+            expect(p2KeepOrder['p2']).toBe(2);
+
+            expect(player1.zones.reserveZone.getAll().length).toBe(1);
+            expect(player1.zones.reserveZone.contains(cardA_P1.instanceId)).toBe(true);
+            expect(player1.zones.discardPileZone.contains(cardB_P1.instanceId)).toBe(true);
+            expect(player1.zones.discardPileZone.contains(cardC_P1.instanceId)).toBe(true);
+
+            expect(player2.zones.reserveZone.getAll().length).toBe(1);
+            expect(player2.zones.reserveZone.contains(cardX_P2.instanceId)).toBe(true);
+            expect(player2.zones.discardPileZone.contains(cardY_P2.instanceId)).toBe(true);
+            expect(player2.zones.discardPileZone.contains(cardZ_P2.instanceId)).toBe(true);
+        });
+    });
+});

--- a/src/engine/tests/unit/PhaseManager.test.ts
+++ b/src/engine/tests/unit/PhaseManager.test.ts
@@ -1,0 +1,171 @@
+import { PhaseManager } from '../../PhaseManager';
+import type { GameStateManager } from '../../GameStateManager';
+import { Player } from '../../Player';
+import type { PlayerActionHandler } from '../../PlayerActionHandler';
+import { ObjectStore } from '../../ObjectStore';
+import { EventBus } from '../../EventBus';
+import { RuleAdjudicator } from '../../RuleAdjudicator';
+import { TurnManager } from '../../TurnManager';
+import type { CardDefinition, ICardInstance, IGameObject, IExpandChoice } from '../../types/objects';
+import { CardType, GamePhase, ZoneIdentifier } from '../../types/enums';
+import { EffectProcessor } from '../../EffectProcessor';
+import { CardPlaySystem } from '../../CardPlaySystem';
+import { StatusHandler } from '../../StatusHandler';
+
+jest.mock('../../PlayerActionHandler');
+jest.mock('../../RuleAdjudicator');
+jest.mock('../../TurnManager');
+jest.mock('../../EffectProcessor');
+jest.mock('../../CardPlaySystem');
+jest.mock('../../StatusHandler');
+
+
+const mockPlayerActionHandler = {
+    playerChoosesObjectsToKeep: jest.fn(),
+    promptForOptionalStepChoice: jest.fn(),
+    promptForModeChoice: jest.fn(),
+    promptForCardChoice: jest.fn(),
+    promptForExpeditionChoice: jest.fn(),
+    promptForPlayerChoice: jest.fn(),
+    chooseTargetForEffect: jest.fn(),
+    promptPlayerForExpandChoice: jest.fn(),
+    promptPlayerForScoutChoice: jest.fn(),
+} as jest.Mocked<PlayerActionHandler>;
+
+
+describe('PhaseManager', () => {
+    let phaseManager: PhaseManager;
+    let gsm: GameStateManager;
+    let player1: Player;
+    let player2: Player;
+    let objectStore: ObjectStore;
+    let eventBus: EventBus;
+    let ruleAdjudicator: RuleAdjudicator;
+    let turnManager: TurnManager;
+    let effectProcessor: EffectProcessor;
+    let cardPlaySystem: CardPlaySystem;
+    let statusHandler: StatusHandler;
+    let mockResolveReactions: jest.SpyInstance;
+    let mockApplyPassives: jest.SpyInstance;
+
+    const cardDefHandP1: CardDefinition = { id: 'handP1Def', name: 'P1 Hand Card', type: CardType.Character, cost: { scout: 1 } };
+    const cardDefHandP2: CardDefinition = { id: 'handP2Def', name: 'P2 Hand Card', type: CardType.Character, cost: { scout: 1 } };
+    const cardDefExpeditionP1: CardDefinition = { id: 'expP1Def', name: 'P1 Expedition Card', type: CardType.Expedition };
+
+
+    beforeEach(() => {
+        eventBus = new EventBus(); // Real EventBus
+        objectStore = new ObjectStore(eventBus);
+        statusHandler = new StatusHandler(objectStore, eventBus);
+        ruleAdjudicator = new RuleAdjudicator(objectStore, eventBus, statusHandler);
+        turnManager = new TurnManager(eventBus, ['p1', 'p2']);
+
+        player1 = new Player('p1', 'Player 1', objectStore, eventBus);
+        player2 = new Player('p2', 'Player 2', objectStore, eventBus);
+
+        objectStore.addPlayer(player1);
+        objectStore.addPlayer(player2);
+
+        objectStore.registerCardDefinition(cardDefHandP1);
+        objectStore.registerCardDefinition(cardDefHandP2);
+        objectStore.registerCardDefinition(cardDefExpeditionP1);
+
+        gsm = new GameStateManager(
+            objectStore,
+            eventBus,
+            ruleAdjudicator,
+            mockPlayerActionHandler as PlayerActionHandler,
+            turnManager,
+            statusHandler
+        );
+        effectProcessor = new EffectProcessor(gsm);
+        cardPlaySystem = new CardPlaySystem(gsm);
+        gsm.effectProcessor = effectProcessor;
+        gsm.cardPlaySystem = cardPlaySystem;
+
+        phaseManager = new PhaseManager(gsm, eventBus, turnManager);
+
+        gsm.initializeGame(['p1', 'p2'], {});
+        gsm.startGame();
+        gsm.state.firstPlayerId = 'p1';
+        gsm.state.currentPlayerId = 'p1';
+
+        mockResolveReactions = jest.spyOn(gsm, 'resolveReactions').mockResolvedValue(undefined);
+        mockApplyPassives = jest.spyOn(ruleAdjudicator, 'applyAllPassiveAbilities').mockImplementation(() => {});
+
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('handleMorning', () => {
+        it('should process expand choices in initiative order with reactions', async () => {
+            const cardP1Hand = objectStore.createCardInstance('handP1Def', 'p1', ZoneIdentifier.Hand) as ICardInstance;
+            player1.zones.handZone.add(objectStore.getObject(cardP1Hand.instanceId) as IGameObject);
+            const cardP2Hand = objectStore.createCardInstance('handP2Def', 'p2', ZoneIdentifier.Hand) as ICardInstance;
+            player2.zones.handZone.add(objectStore.getObject(cardP2Hand.instanceId) as IGameObject);
+
+            const p1ExpeditionCard = objectStore.createCardInstance('expP1Def', 'p1', ZoneIdentifier.Expedition) as ICardInstance;
+            (objectStore.getObject(p1ExpeditionCard.instanceId) as IGameObject).expeditionAssignment = {playerId: 'p1', type: 'hero'};
+            gsm.state.sharedZones.expedition.add(objectStore.getObject(p1ExpeditionCard.instanceId) as IGameObject);
+
+
+            const p1Choice: IExpandChoice = { cardToExpand: cardP1Hand.instanceId, expeditionCardId: p1ExpeditionCard.instanceId, isPass: false };
+            const p2Choice: IExpandChoice = { cardToExpand: cardP2Hand.instanceId, expeditionCardId: '', isPass: false }; // P2 might not have expedition out yet
+
+            let p1PromptOrder = 0;
+            let p2PromptOrder = 0;
+            let p1ReactionOrder = 0;
+            let p2ReactionOrder = 0;
+            let callOrder = 0;
+
+            mockPlayerActionHandler.promptPlayerForExpandChoice.mockImplementation(async (playerId) => {
+                callOrder++;
+                if (playerId === 'p1') {
+                    p1PromptOrder = callOrder;
+                    return p1Choice;
+                }
+                if (playerId === 'p2') {
+                    p2PromptOrder = callOrder;
+                    // Simulate P2 having an expedition card appear or choosing one if logic allows
+                    // For this test, assume P2 can expand to a general area or a newly created one if needed.
+                    // The core is initiative order, so P2's specific valid choice details are secondary here.
+                    // Let's assume P2 chooses to expand to a valid target.
+                    const dummyExpeditionForP2 = objectStore.createCardInstance('expP1Def', 'p2', ZoneIdentifier.Expedition) as ICardInstance;
+                    (objectStore.getObject(dummyExpeditionForP2.instanceId) as IGameObject).expeditionAssignment = {playerId: 'p2', type: 'hero'};
+                    gsm.state.sharedZones.expedition.add(objectStore.getObject(dummyExpeditionForP2.instanceId) as IGameObject);
+                    p2Choice.expeditionCardId = dummyExpeditionForP2.instanceId;
+                    return p2Choice;
+                }
+                return { cardToExpand: '', expeditionCardId: '', isPass: true };
+            });
+
+            mockResolveReactions.mockImplementation(async () => {
+                callOrder++;
+                // Check if it's P1's turn for reaction by seeing if P1 has expanded but P2 hasn't been prompted yet
+                if (p1PromptOrder > 0 && p2PromptOrder === 0) {
+                    p1ReactionOrder = callOrder;
+                     // Simulate P1's reaction: e.g., P1 draws a card
+                    eventBus.publish('simulatedReactionP1', {playerId: 'p1'});
+                } else if (p2PromptOrder > 0) { // P2's turn for reaction
+                    p2ReactionOrder = callOrder;
+                }
+                return Promise.resolve();
+            });
+
+            await phaseManager.handleMorning();
+
+            expect(p1PromptOrder).toBe(1);
+            expect(player1.zones.playZone.contains(cardP1Hand.instanceId)).toBe(true);
+            expect(p1ReactionOrder).toBeGreaterThan(p1PromptOrder);
+
+            expect(p2PromptOrder).toBeGreaterThan(p1ReactionOrder);
+            expect(player2.zones.playZone.contains(cardP2Hand.instanceId)).toBe(true);
+            expect(p2ReactionOrder).toBeGreaterThan(p2PromptOrder);
+
+            expect(mockApplyPassives).toHaveBeenCalledTimes(2); // Once after each player's action
+            expect(mockResolveReactions).toHaveBeenCalledTimes(2); // Once after each player's action
+        });
+    });
+});


### PR DESCRIPTION
This commit implements the Initiative Order rules (Rule 1.4.5 and 6.1.h from the rulebook) across various parts of the game engine.

Key changes:

1.  **PlayerActionHandler**: I confirmed that methods are designed for single-player choices. Callers are responsible for initiative-ordered iteration.

2.  **EffectProcessor**:
    *   `resolveTargetsForStep` now sorts player-based targets (e.g., 'all_players', 'opponent') according to current initiative order.
    *   A new private helper `_processEffectForEachPlayerSequentially` ensures that for "Each player..." effects, each player's action, subsequent passive ability updates, and reaction resolutions are completed before processing the next player.
    *   Effect handlers like `effectDrawCards`, `effectDiscardCards`, `effectSacrifice`, etc., now use this helper for sequential processing when targeting multiple players.

3.  **PhaseManager**:
    *   I verified that `handleMorning` (specifically the Expand step) correctly iterates through players in initiative order, processing each player's expansion choice and any triggered reactions sequentially.

4.  **GameStateManager**:
    *   I ensured `cleanupPhase` iterates through players in initiative order for making choices about discarding/sacrificing cards, with actions for one player resolved before the next player chooses.

5.  **Unit Tests**:
    *   I added new test suites for `GameStateManager`, `EffectProcessor`, and `PhaseManager`.
    *   Tests cover scenarios for `cleanupPhase`, "Each player..." effects (drawing, sacrificing with choice), and the Expand step in `handleMorning`.
    *   These tests verify the correct sequence of operations, choices, state changes, and reaction/passive processing based on initiative order.

These changes ensure that the game correctly handles situations requiring sequential player input or effect application based on the defined initiative rules.